### PR TITLE
Add realtime data collection client/server for collaborative training

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, List
 
-import cv2
 from flask import Flask, redirect, render_template, request, url_for
-from ultralytics import YOLO
 
 from blackjack import ACTION_LABELS_FR, DEFAULT_GAME_RULES, describe_hand, evaluate_hand, get_expert_advice, normalise_hand
 from utils import select_best_device
+from utils.detection import BlackjackDetector
 
 app = Flask(__name__)
 
@@ -23,78 +21,12 @@ app.config["UPLOAD_FOLDER"] = str(UPLOAD_FOLDER)
 UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
 
 print(f"Loading YOLO model from {MODEL_PATH} on device {DEVICE}...")
-model = YOLO(str(MODEL_PATH))
-model.to(DEVICE)
-
-CARD_VALUE_MAP: Dict[str, int] = {
-    "ace": 11,
-    "king": 10,
-    "queen": 10,
-    "jack": 10,
-    "10": 10,
-    "9": 9,
-    "8": 8,
-    "7": 7,
-    "6": 6,
-    "5": 5,
-    "4": 4,
-    "3": 3,
-    "2": 2,
-    "black": 0,
-    "red": 0,
-}
-
-
-def _extract_cards(image_path: str) -> List[Dict[str, object]]:
-    results = model.predict(
-        source=image_path,
-        conf=CONF_THRESHOLD,
-        iou=IOU_THRESHOLD,
-        device=DEVICE,
-        verbose=False,
-    )
-    cards: List[Dict[str, object]] = []
-    for result in results:
-        for box in result.boxes:
-            cls_id = int(box.cls[0])
-            class_name = model.names[int(cls_id)]
-            rank = class_name.split("_")[0]
-            value = CARD_VALUE_MAP.get(rank, 0)
-            x1, y1, x2, y2 = box.xyxy[0].cpu().numpy()
-            cards.append(
-                {
-                    "rank": rank,
-                    "value": value,
-                    "box": (float(x1), float(y1), float(x2), float(y2)),
-                    "confidence": float(box.conf[0]),
-                    "center": ((x1 + x2) / 2, (y1 + y2) / 2),
-                }
-            )
-    return cards
-
-
-def _group_cards(cards: List[Dict[str, object]]) -> tuple[List[Dict[str, object]], Dict[str, object]]:
-    if not cards:
-        return [], {}
-
-    cards_sorted = sorted(cards, key=lambda c: c["center"][1], reverse=True)
-    player_cards = cards_sorted[:2]
-    dealer_candidates = [c for c in cards_sorted[2:] if c["value"] > 0] or cards_sorted[1:]
-    dealer_card = min(dealer_candidates, key=lambda c: c["center"][1]) if dealer_candidates else {}
-    return player_cards, dealer_card
-
-
-def _annotate_image(image_path: str, cards: List[Dict[str, object]]) -> str:
-    image = cv2.imread(image_path)
-    for card in cards:
-        x1, y1, x2, y2 = map(int, card["box"])
-        label = f"{card['rank']} ({card['confidence']:.2f})"
-        cv2.rectangle(image, (x1, y1), (x2, y2), (0, 200, 0), 2)
-        cv2.putText(image, label, (x1, max(0, y1 - 8)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 200, 0), 1)
-    filename = "annotated_" + Path(image_path).name
-    annotated_path = UPLOAD_FOLDER / filename
-    cv2.imwrite(str(annotated_path), image)
-    return url_for("static", filename=f"uploads/{filename}")
+detector = BlackjackDetector(
+    MODEL_PATH,
+    device=DEVICE,
+    conf_threshold=CONF_THRESHOLD,
+    iou_threshold=IOU_THRESHOLD,
+)
 
 
 @app.route("/", methods=["GET", "POST"])
@@ -113,15 +45,12 @@ def upload_file():
         filepath = UPLOAD_FOLDER / file.filename
         file.save(filepath)
 
-        detections = _extract_cards(str(filepath))
-        player_cards, dealer_card = _group_cards(detections)
+        detections = detector.detect(filepath)
+        player_cards, dealer_card = detector.group_cards(detections)
 
         if player_cards and dealer_card:
-            strategy_player_cards = [
-                {"rank": card["rank"], "value": card["value"]}
-                for card in player_cards
-            ]
-            strategy_dealer_card = {"rank": dealer_card["rank"], "value": dealer_card["value"]}
+            strategy_player_cards = [card.to_strategy_card() for card in player_cards]
+            strategy_dealer_card = dealer_card.to_strategy_card()
             advice = get_expert_advice(strategy_player_cards, strategy_dealer_card, DEFAULT_GAME_RULES)
             normalised_player = normalise_hand(strategy_player_cards)
             total, is_soft = evaluate_hand(normalised_player)
@@ -138,7 +67,8 @@ def upload_file():
         else:
             advice_text = "Pas assez de cartes détectées."
 
-        annotated_url = _annotate_image(str(filepath), detections)
+        annotated_path = detector.annotate_image(filepath, detections, UPLOAD_FOLDER)
+        annotated_url = url_for("static", filename=f"uploads/{annotated_path.name}")
 
     return render_template(
         "index.html",

--- a/realtime_service/__init__.py
+++ b/realtime_service/__init__.py
@@ -1,0 +1,12 @@
+"""Realtime client/server utilities for collaborative Blackjack training."""
+
+from .server import create_app
+from .storage import SampleStore
+from .training import TrainingManager, train_from_samples
+
+__all__ = [
+    "create_app",
+    "SampleStore",
+    "TrainingManager",
+    "train_from_samples",
+]

--- a/realtime_service/client.py
+++ b/realtime_service/client.py
@@ -1,0 +1,201 @@
+"""Command-line client for analysing images and submitting data to the server."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import requests
+
+from blackjack import DEFAULT_GAME_RULES, describe_hand, evaluate_hand, get_expert_advice, normalise_hand
+from utils.detection import BlackjackDetector
+
+DEFAULT_MODEL_PATH = Path("runs/detect/blackjack_detector2/weights/best.pt")
+DEFAULT_SERVER = "http://localhost:8000/api/v1"
+
+
+def _encode_image(path: Path) -> str:
+    with path.open("rb") as handle:
+        return base64.b64encode(handle.read()).decode("ascii")
+
+
+def _print_detection_summary(player_cards, dealer_card, advice, total, is_soft) -> None:
+    player_desc = describe_hand(player_cards)
+    dealer_desc = describe_hand([dealer_card])
+    softness = "soft" if is_soft else "hard"
+    print("Player:", player_desc, f"(total {total}, {softness})")
+    print("Dealer:", dealer_desc)
+    print("Advisor action:", advice)
+
+
+def _submit_to_server(
+    server_url: str,
+    payload: Dict[str, Any],
+    *,
+    timeout: float = 10.0,
+) -> None:
+    url = server_url.rstrip("/") + "/samples"
+    response = requests.post(url, json=payload, timeout=timeout)
+    response.raise_for_status()
+    data = response.json()
+    print("Sample stored with id:", data.get("sample_id"))
+
+
+def _request_status(server_url: str) -> None:
+    url = server_url.rstrip("/") + "/status"
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
+    print(json.dumps(response.json(), indent=2))
+
+
+def _trigger_training(server_url: str) -> None:
+    url = server_url.rstrip("/") + "/train"
+    response = requests.post(url, timeout=5)
+    if response.status_code >= 400:
+        print(response.json())
+        response.raise_for_status()
+    print(json.dumps(response.json(), indent=2))
+
+
+def _prepare_payload(
+    client_id: str,
+    player_cards,
+    dealer_card,
+    detections,
+    advice: str,
+    *,
+    player_action: Optional[str],
+    outcome: Optional[str],
+    notes: Optional[str],
+    include_image: bool,
+    image_path: Path,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "client_id": client_id,
+        "player_cards": [card.to_strategy_card() for card in player_cards],
+        "dealer_card": dealer_card.to_strategy_card() if dealer_card else None,
+        "advisor_action": advice,
+        "player_action": player_action or advice,
+        "round_outcome": outcome,
+        "notes": notes,
+        "detections": [card.to_payload() for card in detections],
+    }
+
+    if include_image:
+        payload["image_base64"] = _encode_image(image_path)
+        payload["image_format"] = image_path.suffix.lstrip(".") or "png"
+    return payload
+
+
+def _handle_capture(args: argparse.Namespace) -> None:
+    model_path = Path(args.model_path or DEFAULT_MODEL_PATH)
+    detector = BlackjackDetector(
+        model_path,
+        device=args.device,
+        conf_threshold=args.conf_threshold,
+        iou_threshold=args.iou_threshold,
+    )
+
+    image_path = Path(args.image)
+    if not image_path.exists():
+        raise FileNotFoundError(f"Image not found: {image_path}")
+
+    detections = detector.detect(image_path)
+    player_cards, dealer_card = detector.group_cards(detections)
+    if not player_cards or not dealer_card:
+        print("Impossible de détecter suffisamment de cartes.")
+        return
+
+    player_strategy_cards = [card.to_strategy_card() for card in player_cards]
+    dealer_strategy_card = dealer_card.to_strategy_card()
+    normalised_player = normalise_hand(player_strategy_cards)
+    total, is_soft = evaluate_hand(normalised_player)
+    advice = get_expert_advice(player_strategy_cards, dealer_strategy_card, DEFAULT_GAME_RULES)
+
+    _print_detection_summary(normalised_player, dealer_strategy_card, advice, total, is_soft)
+
+    if args.annotate:
+        output_dir = Path(args.annotation_dir) if args.annotation_dir else image_path.parent
+        annotated_path = detector.annotate_image(image_path, detections, output_dir)
+        print("Annotated image saved to:", annotated_path)
+
+    if not args.send:
+        return
+
+    payload = _prepare_payload(
+        args.client_id,
+        player_cards,
+        dealer_card,
+        detections,
+        advice,
+        player_action=args.player_action,
+        outcome=args.outcome,
+        notes=args.notes,
+        include_image=args.include_image,
+        image_path=image_path,
+    )
+
+    try:
+        _submit_to_server(args.server_url, payload)
+    except requests.RequestException as exc:
+        print("Failed to submit sample:", exc)
+        raise SystemExit(1) from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Realtime Blackjack advisor client")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    capture = subparsers.add_parser("capture", help="Analyse an image and optionally submit it")
+    capture.add_argument("image", help="Image to analyse")
+    capture.add_argument("--model-path", default=str(DEFAULT_MODEL_PATH), help="Path to YOLO weights")
+    capture.add_argument("--device", default=None, help="Torch device override")
+    capture.add_argument("--conf-threshold", type=float, default=0.35, help="Detection confidence threshold")
+    capture.add_argument("--iou-threshold", type=float, default=0.45, help="Detection IOU threshold")
+    capture.add_argument("--client-id", default=os.getenv("BLACKJACK_CLIENT_ID", "cli"), help="Client identifier")
+    capture.add_argument("--player-action", default=None, help="Actual action taken by the player")
+    capture.add_argument("--outcome", default=None, help="Round outcome (win/lose/push)")
+    capture.add_argument("--notes", default=None, help="Optional free-form notes")
+    capture.add_argument("--send", action="store_true", help="Submit the result to the server")
+    capture.add_argument("--include-image", action="store_true", help="Embed the raw image in the submission")
+    capture.add_argument("--annotate", action="store_true", help="Save an annotated copy of the image")
+    capture.add_argument("--annotation-dir", default=None, help="Where to store annotations (default: alongside the image)")
+    capture.add_argument("--server-url", default=DEFAULT_SERVER, help="Realtime server base URL")
+
+    status = subparsers.add_parser("status", help="Display server status")
+    status.add_argument("--server-url", default=DEFAULT_SERVER, help="Realtime server base URL")
+
+    train = subparsers.add_parser("train", help="Trigger training on the server")
+    train.add_argument("--server-url", default=DEFAULT_SERVER, help="Realtime server base URL")
+
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "capture":
+        _handle_capture(args)
+    elif args.command == "status":
+        try:
+            _request_status(args.server_url)
+        except requests.RequestException as exc:
+            print("Unable to fetch status:", exc)
+            raise SystemExit(1) from exc
+    elif args.command == "train":
+        try:
+            _trigger_training(args.server_url)
+        except requests.RequestException as exc:
+            print("Unable to trigger training:", exc)
+            raise SystemExit(1) from exc
+    else:  # pragma: no cover - defensive, should not happen
+        parser.error(f"Unknown command {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/realtime_service/server.py
+++ b/realtime_service/server.py
@@ -1,0 +1,90 @@
+"""Flask application exposing APIs for realtime data collection and training."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from flask import Flask, jsonify, request
+
+from .storage import SampleStore
+from .training import TrainingManager
+
+
+def create_app(config: Dict[str, Any] | None = None) -> Flask:
+    """Create and configure the realtime training server."""
+
+    config = config or {}
+    data_dir = Path(config.get("data_dir") or os.environ.get("BLACKJACK_SERVER_DATA", "server_data"))
+    policy_path = config.get("policy_path") or os.environ.get("BLACKJACK_POLICY_PATH")
+
+    store = SampleStore(data_dir)
+    trainer = TrainingManager(store, output_path=policy_path)
+
+    app = Flask(__name__)
+    app.config["SAMPLE_STORE"] = store
+    app.config["TRAINING_MANAGER"] = trainer
+
+    @app.get("/health")
+    def health() -> Any:
+        return {"status": "ok"}
+
+    @app.get("/api/v1/status")
+    def status() -> Any:
+        trainer_status = trainer.get_status()
+        return jsonify(
+            {
+                "samples": {
+                    "count": store.sample_count(),
+                    "data_dir": str(store.base_dir),
+                },
+                "training": trainer_status,
+                "policy_path": str(trainer.output_path),
+            }
+        )
+
+    @app.post("/api/v1/samples")
+    def submit_sample() -> Any:
+        payload = request.get_json(force=True, silent=True)
+        if not payload:
+            return jsonify({"error": "Invalid JSON payload"}), 400
+        try:
+            record = store.save_sample(payload)
+        except ValueError as exc:
+            logging.exception("Failed to save sample")
+            return jsonify({"error": str(exc)}), 400
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.exception("Unexpected error while saving sample")
+            return jsonify({"error": str(exc)}), 500
+
+        response = {
+            "sample_id": record.sample_id,
+            "timestamp": record.timestamp,
+            "stored_image": record.image_path,
+        }
+        return jsonify(response), 201
+
+    @app.post("/api/v1/train")
+    def trigger_training() -> Any:
+        try:
+            status = trainer.start_training()
+        except RuntimeError as exc:
+            return jsonify({"error": str(exc), "status": trainer.get_status()}), 409
+        return jsonify({"message": "Training started", "status": status})
+
+    @app.get("/api/v1/policy")
+    def get_policy() -> Any:
+        policy = trainer.current_policy()
+        if not policy:
+            return jsonify({"error": "No policy trained yet"}), 404
+        return jsonify(policy)
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    port = int(os.environ.get("BLACKJACK_SERVER_PORT", "8000"))
+    app.run(host="0.0.0.0", port=port)

--- a/realtime_service/storage.py
+++ b/realtime_service/storage.py
@@ -1,0 +1,194 @@
+"""Utilities for ingesting and persisting client submissions."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional
+
+from blackjack import CARD_VALUES
+
+
+@dataclass
+class SampleRecord:
+    """Structured representation of a client submission."""
+
+    sample_id: str
+    timestamp: str
+    client_id: Optional[str]
+    player_cards: List[Dict[str, Any]]
+    dealer_card: Dict[str, Any]
+    advisor_action: Optional[str]
+    player_action: Optional[str]
+    round_outcome: Optional[str]
+    notes: Optional[str]
+    detections: Optional[List[Dict[str, Any]]]
+    image_path: Optional[str]
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, ensure_ascii=False)
+
+
+class SampleStore:
+    """Filesystem-backed storage for realtime gameplay samples."""
+
+    def __init__(self, base_dir: Path | str) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.upload_dir = self.base_dir / "uploads"
+        self.upload_dir.mkdir(parents=True, exist_ok=True)
+        self.samples_path = self.base_dir / "samples.jsonl"
+        self._lock = threading.Lock()
+        self._sample_count = self._initial_count()
+
+    def _initial_count(self) -> int:
+        if not self.samples_path.exists():
+            return 0
+        with self.samples_path.open("r", encoding="utf-8") as handle:
+            return sum(1 for _ in handle)
+
+    def save_sample(self, payload: Mapping[str, Any]) -> SampleRecord:
+        """Validate, persist and return a structured submission."""
+
+        record = self._build_record(payload)
+        with self._lock:
+            with self.samples_path.open("a", encoding="utf-8") as handle:
+                handle.write(record.to_json())
+                handle.write("\n")
+            self._sample_count += 1
+        return record
+
+    def iter_samples(self) -> Iterator[Dict[str, Any]]:
+        """Yield stored submissions as dictionaries."""
+
+        if not self.samples_path.exists():
+            return
+        with self.samples_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+    def sample_count(self) -> int:
+        """Return the number of stored samples."""
+
+        return self._sample_count
+
+    def _build_record(self, payload: Mapping[str, Any]) -> SampleRecord:
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        client_id = str(payload.get("client_id") or "anonymous")
+        player_cards = self._normalise_cards(payload.get("player_cards"), allow_zero=True)
+        dealer_card_list = self._normalise_cards([payload.get("dealer_card")], allow_zero=False)
+        dealer_card = dealer_card_list[0]
+
+        advisor_action = self._normalise_action(payload.get("advisor_action"))
+        player_action = self._normalise_action(payload.get("player_action"))
+        round_outcome = self._normalise_text(payload.get("round_outcome"))
+        notes = self._normalise_text(payload.get("notes"))
+        detections = self._normalise_detections(payload.get("detections"))
+        image_path = self._store_image(payload)
+
+        return SampleRecord(
+            sample_id=str(uuid.uuid4()),
+            timestamp=timestamp,
+            client_id=client_id,
+            player_cards=player_cards,
+            dealer_card=dealer_card,
+            advisor_action=advisor_action,
+            player_action=player_action,
+            round_outcome=round_outcome,
+            notes=notes,
+            detections=detections,
+            image_path=image_path,
+        )
+
+    def _normalise_cards(
+        self,
+        cards: Optional[Iterable[Mapping[str, Any]]],
+        *,
+        allow_zero: bool,
+    ) -> List[Dict[str, Any]]:
+        if not cards:
+            raise ValueError("Card information is required")
+
+        normalised: List[Dict[str, Any]] = []
+        for card in cards:
+            if not card:
+                continue
+            rank = str(card.get("rank", "")).lower().strip()
+            value = card.get("value")
+            if value is None:
+                if rank not in CARD_VALUES:
+                    raise ValueError(f"Unknown card rank '{rank}' and no value provided")
+                value = CARD_VALUES[rank]
+            value = int(value)
+            if value == 0 and not allow_zero:
+                raise ValueError("Dealer card must have a non-zero value")
+            normalised.append({"rank": rank, "value": value})
+
+        if not normalised:
+            raise ValueError("At least one card must be provided")
+        return normalised
+
+    @staticmethod
+    def _normalise_action(action: Any) -> Optional[str]:
+        if action is None:
+            return None
+        text = str(action).strip()
+        return text or None
+
+    @staticmethod
+    def _normalise_text(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _normalise_detections(detections: Any) -> Optional[List[Dict[str, Any]]]:
+        if not detections:
+            return None
+        normalised: List[Dict[str, Any]] = []
+        for detection in detections:
+            if not isinstance(detection, Mapping):
+                continue
+            entry: Dict[str, Any] = {
+                "rank": str(detection.get("rank", "")).lower(),
+                "value": int(detection.get("value", 0)),
+            }
+            if "confidence" in detection:
+                entry["confidence"] = float(detection["confidence"])
+            if "box" in detection:
+                entry["box"] = [float(v) for v in detection["box"]]
+            normalised.append(entry)
+        return normalised or None
+
+    def _store_image(self, payload: Mapping[str, Any]) -> Optional[str]:
+        image_b64 = payload.get("image_base64")
+        if not image_b64:
+            return None
+        image_format = str(payload.get("image_format") or "png").strip(". ") or "png"
+        sample_id = uuid.uuid4().hex
+        filename = f"{sample_id}.{image_format}"
+        target_path = self.upload_dir / filename
+
+        data = base64.b64decode(image_b64)
+        with target_path.open("wb") as handle:
+            handle.write(data)
+        try:
+            relative = target_path.relative_to(self.base_dir)
+            return str(relative)
+        except ValueError:  # pragma: no cover - defensive safety
+            return str(target_path)
+
+
+__all__ = ["SampleStore", "SampleRecord"]

--- a/realtime_service/training.py
+++ b/realtime_service/training.py
@@ -1,0 +1,153 @@
+"""Training utilities for aggregating crowdsourced blackjack data."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional
+
+from blackjack import ACTION_LABELS, normalise_hand, evaluate_hand
+
+
+ActionCounter = Counter
+
+
+def _state_key(total: int, is_soft: bool, dealer_value: int) -> str:
+    kind = "soft" if is_soft else "hard"
+    return f"{total}:{kind}:{dealer_value}"
+
+
+def train_from_samples(
+    samples: Iterable[Mapping[str, object]],
+    output_path: Path | str,
+) -> Dict[str, object]:
+    """Aggregate samples and write a majority-vote policy to ``output_path``."""
+
+    action_space = set(ACTION_LABELS.keys())
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    state_counters: MutableMapping[str, ActionCounter] = defaultdict(ActionCounter)
+    total_samples = 0
+    skipped_samples = 0
+
+    for sample in samples:
+        player_cards = sample.get("player_cards")
+        dealer_card = sample.get("dealer_card")
+        action = sample.get("player_action") or sample.get("advisor_action")
+        if not player_cards or not dealer_card or not action:
+            skipped_samples += 1
+            continue
+
+        try:
+            normalised_player = normalise_hand(player_cards)  # type: ignore[arg-type]
+            dealer_normalised = normalise_hand([dealer_card])  # type: ignore[arg-type]
+            total, is_soft = evaluate_hand(normalised_player)
+            dealer_value = int(dealer_normalised[0]["value"])
+        except Exception:
+            skipped_samples += 1
+            continue
+
+        action_name = str(action)
+        if action_name not in action_space:
+            skipped_samples += 1
+            continue
+
+        key = _state_key(int(total), bool(is_soft), dealer_value)
+        state_counters[key][action_name] += 1
+        total_samples += 1
+
+    states: Dict[str, Dict[str, object]] = {}
+    for key, counter in state_counters.items():
+        if not counter:
+            continue
+        best_action, best_count = counter.most_common(1)[0]
+        total_state_samples = int(sum(counter.values()))
+        states[key] = {
+            "recommended_action": best_action,
+            "confidence": round(best_count / total_state_samples, 4),
+            "total_samples": total_state_samples,
+            "action_counts": {action: int(count) for action, count in counter.items()},
+        }
+
+    payload = {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "total_samples": total_samples,
+            "skipped_samples": skipped_samples,
+            "unique_states": len(states),
+        },
+        "states": states,
+    }
+
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+    return payload
+
+
+class TrainingManager:
+    """Coordinates background training jobs for the realtime server."""
+
+    def __init__(self, store, output_path: Path | str | None = None) -> None:
+        self.store = store
+        self.output_path = Path(output_path or Path("model") / "community_policy.json")
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._status: Dict[str, object] = {
+            "running": False,
+            "started_at": None,
+            "completed_at": None,
+            "error": None,
+            "last_result": None,
+        }
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+
+    def start_training(self) -> Dict[str, object]:
+        with self._lock:
+            if self._status["running"]:
+                raise RuntimeError("Training already in progress")
+            self._status.update(
+                running=True,
+                started_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                completed_at=None,
+                error=None,
+            )
+            self._thread = threading.Thread(target=self._run_training, daemon=True)
+            self._thread.start()
+            return dict(self._status)
+
+    def _run_training(self) -> None:
+        try:
+            result = train_from_samples(self.store.iter_samples(), self.output_path)
+            status_update = {
+                "running": False,
+                "completed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "last_result": result,
+                "error": None,
+            }
+        except Exception as exc:  # pragma: no cover - defensive logging
+            status_update = {
+                "running": False,
+                "completed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "error": str(exc),
+                "last_result": None,
+            }
+        with self._lock:
+            self._status.update(status_update)
+
+    def get_status(self) -> Dict[str, object]:
+        with self._lock:
+            return dict(self._status)
+
+    def current_policy(self) -> Optional[Dict[str, object]]:
+        if not self.output_path.exists():
+            return None
+        with self.output_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+
+__all__ = ["TrainingManager", "train_from_samples"]

--- a/tests/test_realtime_training.py
+++ b/tests/test_realtime_training.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import base64
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Dict
+
+from realtime_service.storage import SampleStore
+from realtime_service.training import TrainingManager, train_from_samples
+
+
+def _sample_payload(**overrides: Dict[str, object]) -> Dict[str, object]:
+    payload = {
+        "client_id": "test-client",
+        "player_cards": [
+            {"rank": "10", "value": 10},
+            {"rank": "6", "value": 6},
+        ],
+        "dealer_card": {"rank": "9", "value": 9},
+        "advisor_action": "Hit",
+        "player_action": "Hit",
+        "round_outcome": "win",
+        "notes": "sample",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class SampleStoreTests(unittest.TestCase):
+    def test_sample_store_persists_image(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SampleStore(tmpdir)
+            image_bytes = base64.b64encode(b"image").decode("ascii")
+            payload = _sample_payload(image_base64=image_bytes, image_format="dat")
+            record = store.save_sample(payload)
+
+            self.assertIsNotNone(record.image_path)
+            stored_path = Path(tmpdir) / record.image_path  # type: ignore[operator]
+            self.assertTrue(stored_path.exists())
+            self.assertEqual(store.sample_count(), 1)
+
+            stored = list(store.iter_samples())
+            self.assertEqual(len(stored), 1)
+            self.assertEqual(stored[0]["player_cards"][0]["rank"], "10")
+
+
+class TrainingTests(unittest.TestCase):
+    def test_train_from_samples_creates_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SampleStore(tmpdir)
+            store.save_sample(_sample_payload())
+            store.save_sample(_sample_payload(player_action="Stand"))
+            store.save_sample(_sample_payload(player_action="Hit"))
+
+            output_path = Path(tmpdir) / "policy.json"
+            result = train_from_samples(store.iter_samples(), output_path)
+
+            self.assertTrue(output_path.exists())
+            state_id, state_data = next(iter(result["states"].items()))
+            self.assertEqual(state_data["recommended_action"], "Hit")
+            self.assertEqual(state_data["action_counts"]["Hit"], 2)
+            self.assertEqual(state_data["action_counts"]["Stand"], 1)
+            self.assertEqual(result["metadata"]["total_samples"], 3)
+
+    def test_training_manager_runs_background_job(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = SampleStore(tmpdir)
+            store.save_sample(_sample_payload())
+            output_path = Path(tmpdir) / "policy.json"
+            manager = TrainingManager(store, output_path=output_path)
+
+            status = manager.start_training()
+            self.assertTrue(status["running"])
+
+            manager._thread.join(timeout=5)  # type: ignore[attr-defined]
+            final_status = manager.get_status()
+            self.assertFalse(final_status["running"])
+            self.assertIsNotNone(final_status.get("last_result"))
+            self.assertTrue(output_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/detection.py
+++ b/utils/detection.py
@@ -1,0 +1,165 @@
+"""Reusable Blackjack card detection helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import cv2
+from ultralytics import YOLO
+
+from utils import select_best_device
+
+CARD_VALUE_MAP: Dict[str, int] = {
+    "ace": 11,
+    "king": 10,
+    "queen": 10,
+    "jack": 10,
+    "10": 10,
+    "9": 9,
+    "8": 8,
+    "7": 7,
+    "6": 6,
+    "5": 5,
+    "4": 4,
+    "3": 3,
+    "2": 2,
+    "black": 0,
+    "red": 0,
+}
+
+
+@dataclass
+class CardDetection:
+    """Represents a single detected card in an image."""
+
+    rank: str
+    value: int
+    box: Tuple[float, float, float, float]
+    confidence: float
+    center: Tuple[float, float]
+
+    def to_strategy_card(self) -> Dict[str, int]:
+        """Return a simplified mapping compatible with strategy helpers."""
+
+        return {"rank": self.rank, "value": int(self.value)}
+
+    def to_payload(self) -> Dict[str, object]:
+        """Return a serialisable representation for API payloads."""
+
+        return {
+            "rank": self.rank,
+            "value": int(self.value),
+            "box": tuple(float(coord) for coord in self.box),
+            "confidence": float(self.confidence),
+            "center": tuple(float(c) for c in self.center),
+        }
+
+
+class BlackjackDetector:
+    """Wrapper around a YOLO model to detect blackjack cards."""
+
+    def __init__(
+        self,
+        model_path: Path | str,
+        *,
+        device: Optional[str] = None,
+        conf_threshold: float = 0.35,
+        iou_threshold: float = 0.45,
+        card_value_map: Optional[Dict[str, int]] = None,
+    ) -> None:
+        self.model_path = Path(model_path)
+        if not self.model_path.exists():
+            raise FileNotFoundError(f"Model weights not found at {self.model_path}")
+
+        self.card_value_map = dict(card_value_map or CARD_VALUE_MAP)
+        requested_device = device or os.environ.get("YOLO_DEVICE")
+        self.device = select_best_device(requested_device)
+        self.conf_threshold = float(conf_threshold)
+        self.iou_threshold = float(iou_threshold)
+
+        self.model = YOLO(str(self.model_path))
+        self.model.to(self.device)
+
+    def detect(self, image_path: Path | str) -> List[CardDetection]:
+        """Run the YOLO model and return all detected cards."""
+
+        results = self.model.predict(
+            source=str(image_path),
+            conf=self.conf_threshold,
+            iou=self.iou_threshold,
+            device=self.device,
+            verbose=False,
+        )
+        detections: List[CardDetection] = []
+        for result in results:
+            for box in result.boxes:
+                cls_id = int(box.cls[0])
+                class_name = self.model.names[int(cls_id)]
+                rank = class_name.split("_")[0]
+                value = int(self.card_value_map.get(rank, 0))
+                x1, y1, x2, y2 = box.xyxy[0].cpu().numpy()
+                detections.append(
+                    CardDetection(
+                        rank=rank,
+                        value=value,
+                        box=(float(x1), float(y1), float(x2), float(y2)),
+                        confidence=float(box.conf[0]),
+                        center=((float(x1) + float(x2)) / 2, (float(y1) + float(y2)) / 2),
+                    )
+                )
+        return detections
+
+    @staticmethod
+    def group_cards(cards: Sequence[CardDetection]) -> Tuple[List[CardDetection], Optional[CardDetection]]:
+        """Split detections into player cards and dealer up-card."""
+
+        if not cards:
+            return [], None
+
+        cards_sorted = sorted(cards, key=lambda c: c.center[1], reverse=True)
+        player_cards = list(cards_sorted[:2])
+        dealer_candidates = [card for card in cards_sorted[2:] if card.value > 0] or cards_sorted[1:]
+        dealer_card = min(dealer_candidates, key=lambda c: c.center[1]) if dealer_candidates else None
+        return player_cards, dealer_card
+
+    @staticmethod
+    def annotate_image(
+        image_path: Path | str,
+        detections: Sequence[CardDetection],
+        output_dir: Path,
+    ) -> Path:
+        """Return a path to an annotated copy of the analysed image."""
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        image = cv2.imread(str(image_path))
+        for card in detections:
+            x1, y1, x2, y2 = map(int, card.box)
+            label = f"{card.rank} ({card.confidence:.2f})"
+            cv2.rectangle(image, (x1, y1), (x2, y2), (0, 200, 0), 2)
+            cv2.putText(
+                image,
+                label,
+                (x1, max(0, y1 - 8)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (0, 200, 0),
+                1,
+            )
+
+        annotated_path = output_dir / f"annotated_{Path(image_path).name}"
+        cv2.imwrite(str(annotated_path), image)
+        return annotated_path
+
+    @staticmethod
+    def serialize_detections(detections: Iterable[CardDetection]) -> List[Dict[str, object]]:
+        """Serialise detections into dictionaries."""
+
+        return [card.to_payload() for card in detections]
+
+
+__all__ = ["BlackjackDetector", "CardDetection", "CARD_VALUE_MAP"]


### PR DESCRIPTION
## Summary
- extract reusable YOLO detection helper and simplify the web app to use it
- add a realtime_service package with a Flask API, CLI client, and background trainer for crowdsourced data
- document the collaborative workflow and cover the new storage/training logic with unit tests

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e517647c9883229dc73591e5e683d7